### PR TITLE
Replay multi-character maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ To see what keystrokes are used for the above example, see [this issue](https://
 - Live update in Insert mode
 - One key to rule it all! See [Quick Start](#quick-start) on what the key does in different scenarios
 - Works in Normal, Insert, and Visual mode for any commands (including
-  multi-key commands like `dw`!)
+  multi-key commands, assuming you set `g:multicursor_insert_maps` and
+  `g:multicursor_normal_maps`; see Settings below for details)
 
 ## Installation
 Install using [Pathogen], [Vundle], [Neobundle], or your favorite Vim package manager.

--- a/README.md
+++ b/README.md
@@ -69,13 +69,22 @@ let g:multi_cursor_start_key='<F6>'
 **NOTE:** Prior to version 1.3, the recommended way to map the keys is using the expression quote syntax in Vim, using something like `"\<C-n>"` or `"\<Esc>"` (see h: expr-quote). After 1.3, the recommended way is to use a raw string like above. If your key mappings don't appear to work, give the new syntax a try.
 
 ## Setting
-Currently there're two additional global settings one can tweak:
+Currently there're three additional global settings one can tweak:
 ### ```g:multi_cursor_exit_from_visual_mode``` (Default: 1)
 
 If set to 0, then pressing `g:multi_cursor_quit_key` in _Visual_ mode will not quit and delete all existing cursors. This is useful if you want to press Escape and go back to Normal mode, and still be able to operate on all the cursors.
 
 ### ```g:multi_cursor_exit_from_insert_mode``` (Default: 1)
 If set to 0, then pressing `g:multi_cursor_quit_key` in _Insert_ mode will not quit and delete all existing cursors. This is useful if you want to press Escape and go back to Normal mode, and still be able to operate on all the cursors.
+
+### ```g:multi_cursor_insert_maps``` (Default: `{}`)
+Any key in this map (values are ignored) will cause multi-cursor _Insert_ mode
+to pause for `timeoutlen` waiting for map completion just like normal vim.
+Otherwise keys mapped in insert mode are ignored when multiple cursors are
+active. For example, setting it to `{'\':1}` will make insert-mode mappings
+beginning with the default leader key work in multi-cursor mode. You have to
+manually set this because vim doesn't provide a way to see which keys *start*
+mappings.
 
 ### Highlight
 The plugin uses the highlight group `multiple_cursors_cursor` and `multiple_cursors_visual` to highlight the virtual cursors and their visual selections respectively. You can customize them by putting something similar like the following in your vimrc:
@@ -87,9 +96,6 @@ highlight link multiple_cursors_visual Visual
 ```
 
 ## Issues
-- There is a bit of lag sometimes due to how multi-key support was added, but
-  it's like vim's lag when entering a character with a possible mapping: if you
-  ignore it and keep typing it is just a visual delay.
 - Select mode is not implemented
 
 ## Changelog

--- a/README.md
+++ b/README.md
@@ -86,6 +86,15 @@ beginning with the default leader key work in multi-cursor mode. You have to
 manually set this because vim doesn't provide a way to see which keys *start*
 mappings.
 
+### ```g:multi_cursor_normal_maps``` (Default: `{}`)
+Any key in this map (values are ignored) will cause multi-cursor _Normal_ mode
+to pause for map completion just like normal vim. Otherwise keys mapped in
+normal mode will "fail to replay" when multiple cursors are active. For example,
+setting it to `{'d':1}` will make normal-mode mappings beginning with `d` (such
+as `dw` to delete a word) work in multi-cursor mode. You have to
+manually set this because vim doesn't provide a way to see which keys *start*
+mappings; setting it to include motion commands like `j` can break things.
+
 ### Highlight
 The plugin uses the highlight group `multiple_cursors_cursor` and `multiple_cursors_visual` to highlight the virtual cursors and their visual selections respectively. You can customize them by putting something similar like the following in your vimrc:
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ To see what keystrokes are used for the above example, see [this issue](https://
 ## Features
 - Live update in Insert mode
 - One key to rule it all! See [Quick Start](#quick-start) on what the key does in different scenarios
-- Works in Normal, Insert, and Visual mode for SINGLE key command
+- Works in Normal, Insert, and Visual mode for any commands (including
+  multi-key commands like `dw`!)
 
 ## Installation
 Install using [Pathogen], [Vundle], [Neobundle], or your favorite Vim package manager.
@@ -61,11 +62,11 @@ By default, the 'next' key is also used to enter multicursor mode. If you want t
 let g:multi_cursor_start_key='<F6>'
 ```
 
-**IMPORTANT:** Please note that currently only single keystrokes and special keys can be mapped. This contraint is also the reason why multikey commands such as `ciw` do not work and cause unexpected behavior in Normal mode. This means that a mapping like `<Leader>n` will NOT work correctly. For a list of special keys that are supported, see `help :key-notation`
+**IMPORTANT:** Please note that currently only single keystrokes and special keys can be mapped. This means that a mapping like `<Leader>n` will NOT work correctly. For a list of special keys that are supported, see `help :key-notation`
 
 **NOTE:** Please make sure to always map something to `g:multi_cursor_quit_key`, otherwise you'll have a tough time quitting from multicursor mode.
 
-**NOTE:** Prior to version 1.3, the recommended way to map the keys is using the expressoin quote syntax in Vim, using something like `"\<C-n>"` or `"\<Esc>"` (see h: expr-quote). After 1.3, the recommended way is to use a raw string like above. If your key mappings don't appear to work, give the new syntax a try.
+**NOTE:** Prior to version 1.3, the recommended way to map the keys is using the expression quote syntax in Vim, using something like `"\<C-n>"` or `"\<Esc>"` (see h: expr-quote). After 1.3, the recommended way is to use a raw string like above. If your key mappings don't appear to work, give the new syntax a try.
 
 ## Setting
 Currently there're two additional global settings one can tweak:
@@ -86,8 +87,9 @@ highlight link multiple_cursors_visual Visual
 ```
 
 ## Issues
-- Multi key commands like `ciw` do not work at the moment
-- All user input typed before Vim is able to fan out the last operation to all cursors is lost. This is a implementation decision to keep the input perfectly synced in all locations, at the cost of potentially losing user input.
+- There is a bit of lag sometimes due to how multi-key support was added, but
+  it's like vim's lag when entering a character with a possible mapping: if you
+  ignore it and keep typing it is just a visual delay.
 - Select mode is not implemented
 
 ## Changelog

--- a/autoload/multiple_cursors.vim
+++ b/autoload/multiple_cursors.vim
@@ -764,8 +764,6 @@ function! s:feedkeys(keys)
       endif
     elseif char_type == 1 " char with more than 8 bits (as string)
       let s:saved_keys .= c
-    else " I think this will never happen
-      echo "Unknown char_type in multiple_cursor:wait_for_user_input(): ".char_type." c=".c
     endif
   endwhile
   call feedkeys(a:keys)
@@ -1027,6 +1025,24 @@ function! s:wait_for_user_input(mode)
     let s:saved_keys = ""
   else
     let s:char = s:get_char()
+  endif
+
+  if has_key(g:multi_cursor_insert_maps, s:last_char())
+    let c = getchar(0)
+    let char_type = type(c)
+    let poll_count = 0
+    while char_type == 0 && c == 0 && poll_count < &timeoutlen
+      sleep 1m
+      let c = getchar(0)
+      let char_type = type(c)
+      let poll_count += 1
+    endwhile
+
+    if char_type == 0 && c != 0
+      let s:char .= nr2char(c)
+    elseif char_type == 1 " char with more than 8 bits (as string)
+      let s:char .= c
+    endif
   endif
 
   call s:start_latency_measure()

--- a/autoload/multiple_cursors.vim
+++ b/autoload/multiple_cursors.vim
@@ -1027,7 +1027,7 @@ function! s:wait_for_user_input(mode)
     let s:char = s:get_char()
   endif
 
-  if has_key(g:multi_cursor_insert_maps, s:last_char())
+  if s:from_mode ==# 'i' && has_key(g:multi_cursor_insert_maps, s:last_char())
     let c = getchar(0)
     let char_type = type(c)
     let poll_count = 0

--- a/autoload/multiple_cursors.vim
+++ b/autoload/multiple_cursors.vim
@@ -1021,8 +1021,13 @@ function! s:wait_for_user_input(mode)
 
   call s:end_latency_measure()
 
-  let s:char = s:saved_keys . s:get_char()
-  let s:saved_keys = ""
+  if len(s:saved_keys) > 0
+    let s:char = s:saved_keys
+    let s:saved_keys = ""
+  else
+    let s:char = s:get_char()
+  endif
+
   while 1
     let c = getchar(0)
     " Checking type is important, when strings are compared with integers,
@@ -1055,7 +1060,7 @@ function! s:wait_for_user_input(mode)
   endif
 
   " If the key is a special key and we're in the right mode, handle it
-  if index(get(s:special_keys, s:from_mode, []), s:char) != -1
+  if index(get(s:special_keys, s:from_mode, []), s:char[len(s:char)-1]) != -1
     call s:handle_special_key(s:char[len(s:char)-1], s:from_mode)
     call s:skip_latency_measure()
   else

--- a/autoload/multiple_cursors.vim
+++ b/autoload/multiple_cursors.vim
@@ -893,7 +893,7 @@ endfunction
 " Quits multicursor mode and clears all cursors. Return true if exited
 " successfully.
 function! s:exit()
-  if s:char !=# g:multi_cursor_quit_key
+  if s:char[len(s:char)-1] !=# g:multi_cursor_quit_key
     return 0
   endif
   let exit = 0

--- a/autoload/multiple_cursors.vim
+++ b/autoload/multiple_cursors.vim
@@ -1054,16 +1054,14 @@ function! s:wait_for_user_input(mode)
     elseif char_type == 1 " char with more than 8 bits (as string)
       let s:char .= c
     endif
-  else
-    if s:char[0] ==# ":"
-      call s:feedkeys(s:char)
-      call s:cm.reset(1, 1)
-      return
-    elseif s:from_mode ==# 'n'
-      while match(s:last_char(), "\\d") == 0
-        let s:char .= s:get_char()
-      endwhile
-    endif
+  elseif s:from_mode !=# 'i' && s:char[0] ==# ":"
+    call s:feedkeys(s:char)
+    call s:cm.reset(1, 1)
+    return
+  elseif s:from_mode ==# 'n'
+    while match(s:last_char(), "\\d") == 0
+      let s:char .= s:get_char()
+    endwhile
   endif
 
   call s:start_latency_measure()

--- a/autoload/multiple_cursors.vim
+++ b/autoload/multiple_cursors.vim
@@ -1054,11 +1054,17 @@ function! s:wait_for_user_input(mode)
     elseif char_type == 1 " char with more than 8 bits (as string)
       let s:char .= c
     endif
+  else
+    if s:char[0] ==# ":"
+      call s:feedkeys(s:char)
+      call s:cm.reset(1, 1)
+      return
+    elseif s:from_mode ==# 'n'
+      while match(s:last_char(), "\\d") == 0
+        let s:char .= s:get_char()
+      endwhile
+    endif
   endif
-
-  while s:from_mode ==# 'n' && match(s:last_char(), "\\d") == 0
-    let s:char .= s:get_char()
-  endwhile
 
   call s:start_latency_measure()
 

--- a/autoload/multiple_cursors.vim
+++ b/autoload/multiple_cursors.vim
@@ -960,8 +960,15 @@ function! s:revert_highlight_fix()
 endfunction
 
 function! s:display_error()
-  if s:bad_input > 0
+  if s:bad_input == s:cm.size()
+    " we couldn't replay it anywhere, it could be the beginning of a multi-key
+    " map like the `d` in `dw`
     let s:saved_keys = s:char . s:saved_keys
+  elseif s:bad_input > 0
+    echohl ErrorMsg |
+          \ echo "Key '".s:char."' cannot be replayed at ".
+          \ s:bad_input." cursor location".(s:bad_input == 1 ? '' : 's') |
+          \ echohl Normal
   endif
   let s:bad_input = 0
 endfunction

--- a/autoload/multiple_cursors.vim
+++ b/autoload/multiple_cursors.vim
@@ -536,6 +536,7 @@ function! s:CursorManager.initialize() dict
   let &cursorline = 0
   let &lazyredraw = 1
   let &paste = 0
+  inoremap <silent> <Esc> <Esc>`^
   " We could have already saved the view from multiple_cursors#find
   if !self.start_from_find
     let self.saved_winview = winsaveview()
@@ -738,12 +739,10 @@ endfunction
 function! s:revert_mode(from, to)
   if a:to ==# 'v'
     call s:cm.reapply_visual_selection()
-  endif
-  if a:to ==# 'V'
+  elseif a:to ==# 'V'
     call s:cm.reapply_visual_selection()
     normal! V
-  endif
-  if a:to ==# 'n' && a:from ==# 'i'
+  elseif a:to ==# 'n' && a:from ==# 'i'
     stopinsert
   endif
 endfunction
@@ -907,6 +906,7 @@ function! s:exit()
     let exit = 1
   endif
   if exit
+    iunmap <silent> <Esc>
     call s:cm.reset(1, 1)
     return 1
   endif

--- a/autoload/multiple_cursors.vim
+++ b/autoload/multiple_cursors.vim
@@ -1056,6 +1056,10 @@ function! s:wait_for_user_input(mode)
     endif
   endif
 
+  while s:from_mode ==# 'n' && match(s:last_char(), "\\d") == 0
+    let s:char .= s:get_char()
+  endwhile
+
   call s:start_latency_measure()
 
   " Clears any echoes we might've added

--- a/autoload/multiple_cursors.vim
+++ b/autoload/multiple_cursors.vim
@@ -1055,7 +1055,7 @@ function! s:wait_for_user_input(mode)
       let s:char .= c
     endif
   elseif s:from_mode !=# 'i' && s:char[0] ==# ":"
-    call s:feedkeys(s:char)
+    call feedkeys(s:char)
     call s:cm.reset(1, 1)
     return
   elseif s:from_mode ==# 'n'

--- a/autoload/multiple_cursors.vim
+++ b/autoload/multiple_cursors.vim
@@ -963,10 +963,7 @@ endfunction
 
 function! s:display_error()
   if s:bad_input > 0
-    echohl ErrorMsg |
-          \ echo "Key '".s:char."' cannot be replayed at ".
-          \ s:bad_input." cursor location".(s:bad_input == 1 ? '' : 's') |
-          \ echohl Normal
+    let s:saved_keys = s:char . s:saved_keys
   endif
   let s:bad_input = 0
 endfunction
@@ -1031,28 +1028,6 @@ function! s:wait_for_user_input(mode)
   else
     let s:char = s:get_char()
   endif
-
-  while index(get(s:special_keys, s:from_mode, []), s:last_char()) == -1
-    let c = getchar(0)
-    " Checking type is important, when strings are compared with integers,
-    " strings are always converted to ints, and all strings are equal to 0
-    let char_type = type(c)
-    if char_type == 0 && c == 0 " Buffer is empty
-      sleep 100m
-      let c = getchar(0)
-      let char_type = type(c)
-      if char_type == 0 && c == 0 " Buffer is empty
-        break
-      endif
-    endif
-    if char_type == 0 " 8-bit char (as number)
-      let s:char .= nr2char(c)
-    elseif char_type == 1 " char with more than 8 bits (as string)
-      let s:char .= c
-    else " I think this will never happen
-      echo "Unknown char_type in multiple_cursor:wait_for_user_input(): ".char_type." c=".c
-    endif
-  endwhile
 
   call s:start_latency_measure()
 

--- a/autoload/multiple_cursors.vim
+++ b/autoload/multiple_cursors.vim
@@ -961,9 +961,9 @@ endfunction
 
 let s:retry_keys = ""
 function! s:display_error()
-  if s:bad_input == s:cm.size()
-    " we couldn't replay it anywhere, it could be the beginning of a multi-key
-    " map like the `d` in `dw`
+  if s:bad_input == s:cm.size() && has_key(g:multi_cursor_normal_maps, s:char[0])
+    " we couldn't replay it anywhere but we're told it's the beginning of a
+    " multi-character map like the `d` in `dw`
     let s:retry_keys = s:char
   else
     let s:retry_keys = ""

--- a/autoload/multiple_cursors.vim
+++ b/autoload/multiple_cursors.vim
@@ -444,6 +444,8 @@ function! s:CursorManager.update_current() dict
     call cur.update_visual_selection(s:get_visual_region(s:pos('.')))
   elseif s:from_mode ==# 'v' || s:from_mode ==# 'V'
     call cur.remove_visual_selection()
+  elseif s:from_mode ==# 'i' && s:to_mode ==# 'n' && self.current_index == self.size() - 1
+    normal! `^
   endif
   let vdelta = line('$') - s:saved_linecount
   " If the total number of lines changed in the buffer, we need to potentially
@@ -536,7 +538,6 @@ function! s:CursorManager.initialize() dict
   let &cursorline = 0
   let &lazyredraw = 1
   let &paste = 0
-  inoremap <silent> <Esc> <Esc>`^
   " We could have already saved the view from multiple_cursors#find
   if !self.start_from_find
     let self.saved_winview = winsaveview()
@@ -904,7 +905,6 @@ function! s:exit()
     let exit = 1
   endif
   if exit
-    iunmap <silent> <Esc>
     call s:cm.reset(1, 1)
     return 1
   endif

--- a/autoload/multiple_cursors.vim
+++ b/autoload/multiple_cursors.vim
@@ -892,7 +892,7 @@ endfunction
 " Quits multicursor mode and clears all cursors. Return true if exited
 " successfully.
 function! s:exit()
-  if s:char[len(s:char)-1] !=# g:multi_cursor_quit_key
+  if s:last_char() !=# g:multi_cursor_quit_key
     return 0
   endif
   let exit = 0
@@ -1002,6 +1002,10 @@ function! s:end_latency_measure()
   let s:skip_latency_measure = 0
 endfunction
 
+function! s:last_char()
+  return s:char[len(s:char)-1]
+endfunction
+
 function! s:wait_for_user_input(mode)
   let s:from_mode = a:mode
   if empty(a:mode)
@@ -1028,7 +1032,7 @@ function! s:wait_for_user_input(mode)
     let s:char = s:get_char()
   endif
 
-  while 1
+  while index(get(s:special_keys, s:from_mode, []), s:last_char()) == -1
     let c = getchar(0)
     " Checking type is important, when strings are compared with integers,
     " strings are always converted to ints, and all strings are equal to 0
@@ -1060,8 +1064,8 @@ function! s:wait_for_user_input(mode)
   endif
 
   " If the key is a special key and we're in the right mode, handle it
-  if index(get(s:special_keys, s:from_mode, []), s:char[len(s:char)-1]) != -1
-    call s:handle_special_key(s:char[len(s:char)-1], s:from_mode)
+  if index(get(s:special_keys, s:from_mode, []), s:last_char()) != -1
+    call s:handle_special_key(s:last_char(), s:from_mode)
     call s:skip_latency_measure()
   else
     call s:cm.start_loop()

--- a/plugin/multiple_cursors.vim
+++ b/plugin/multiple_cursors.vim
@@ -31,6 +31,7 @@ let s:settings = {
       \ 'exit_from_insert_mode': 1,
       \ 'use_default_mapping': 1,
       \ 'debug_latency': 0,
+      \ 'insert_maps': 0,
       \ }
 
 let s:settings_if_default = {

--- a/plugin/multiple_cursors.vim
+++ b/plugin/multiple_cursors.vim
@@ -34,6 +34,7 @@ let s:settings = {
       \ }
 
 let g:multi_cursor_insert_maps = get(g:, 'multi_cursor_insert_maps', {})
+let g:multi_cursor_normal_maps = get(g:, 'multi_cursor_normal_maps', {})
 
 let s:settings_if_default = {
       \ 'quit_key': '<Esc>',

--- a/plugin/multiple_cursors.vim
+++ b/plugin/multiple_cursors.vim
@@ -31,8 +31,9 @@ let s:settings = {
       \ 'exit_from_insert_mode': 1,
       \ 'use_default_mapping': 1,
       \ 'debug_latency': 0,
-      \ 'insert_maps': 0,
       \ }
+
+let g:multi_cursor_insert_maps = get(g:, 'multi_cursor_insert_maps', {})
 
 let s:settings_if_default = {
       \ 'quit_key': '<Esc>',


### PR DESCRIPTION
Also save and replay characters that would otherwise be "lost".

@kris89 this seems to work for me to permit multi-character mappings (like `dw`) to be replayed in multi-cursor mode although it does introduce a little bit of lag. The lag caused a lot more keys to be dropped, so I adapted and simplified @joeytwiddle's fix for that.

I thought about making the `100m` time configurable, but I couldn't figure out how since it isn't really an integer or a string; I don't fully understand how vim's type system works with `sleep`.

This is my first non-trivial vimscript work so please be patient if I've done something stupid :)
