### PR TITLE
Improve Multiple_cursors_before and Multiple_cursors_after examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ I've added two helpful functions to this fork to prevent conflicts with some oth
 For example, if you are using [Neocomplete](https://github.com/Shougo/neocomplete.vim), add this to your vimrc to prevent conflict:
 
 ````
+" Called once right before you start selecting multiple cursors
 function! Multiple_cursors_before()
   if exists(':NeoCompleteLock')==2
     exe 'NeoCompleteLock'

--- a/README.md
+++ b/README.md
@@ -8,14 +8,17 @@ I've added two helpful functions to this fork to prevent conflicts with some oth
 For example, if you are using [Neocomplete](https://github.com/Shougo/neocomplete.vim), add this to your vimrc to prevent conflict:
 
 ````
-" Called once right before you start selecting multiple cursors
 function! Multiple_cursors_before()
+  if exists(':NeoCompleteLock')==2
     exe 'NeoCompleteLock'
+  endif
 endfunction
 
 " Called once only when the multiple selection is canceled (default <Esc>)
 function! Multiple_cursors_after()
+  if exists(':NeoCompleteUnlock')==2
     exe 'NeoCompleteUnlock'
+  endif
 endfunction
 ````
 


### PR DESCRIPTION
Add check for existence of :NeoCompleteLock and :NeoCompleteUnlock prior to trying to exec them. This is needed in the case of delayed activation of neocomplete (e.g. with NeoBundleLazy).
